### PR TITLE
Add GetDeviceInfo()

### DIFF
--- a/GetDeviceInfo.go
+++ b/GetDeviceInfo.go
@@ -1,0 +1,39 @@
+package netgear_client
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// Implements the DeviceInfo/GetInfo SOAP message
+func (client *NetgearClient) GetDeviceInfo() (map[string]string, error) {
+	const ACTION = "urn:NETGEAR-ROUTER:service:DeviceInfo:1#GetInfo"
+	const REQUEST = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<SOAP-ENV:Envelope
+	xmlns:SOAPSDK1="http://www.w3.org/2001/XMLSchema"
+	xmlns:SOAPSDK2="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:SOAPSDK3="http://schemas.xmlsoap.org/soap/encoding/"
+	xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+	<SOAP-ENV:Header>
+		<SessionID>%s</SessionID>
+	</SOAP-ENV:Header>
+</SOAP-ENV:Envelope>`
+
+	response, err := client.send_request(ACTION, fmt.Sprintf(REQUEST, client.sessionid), true)
+	if err != nil {
+		return make(map[string]string), err
+	}
+
+	var inside Node
+	err = xml.Unmarshal(response, &inside)
+	if err != nil {
+		return make(map[string]string), fmt.Errorf("failed to unmarshal response from inside SOAP body: %v", err)
+	}
+
+	var info = make(map[string]string)
+	for _, node := range inside.Nodes {
+		name := node.XMLName.Local
+		info[name] = node.Content
+	}
+	return info, nil
+}

--- a/GetDeviceInfo_test.go
+++ b/GetDeviceInfo_test.go
@@ -1,0 +1,59 @@
+package netgear_client
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGetInfo(t *testing.T) {
+	debug := true
+
+	if get_password() == "" {
+		t.Fatal("Error: NETGEAR_PASSWORD environment variable is not set")
+	}
+
+	client, err := NewNetgearClient(get_url(), true, get_username(), get_password(), 5, debug)
+	if err != nil {
+		t.Fatalf("Error getting a client: %s", err)
+	}
+
+	res, err := client.GetDeviceInfo()
+	if err != nil {
+		t.Fatalf("Error getting device info: %s", err)
+	}
+	if len(res) == 0 {
+		t.Fatalf("Unexpected empty response")
+	}
+
+	expected := [...]string{
+		"Description",
+		"DeviceMode",
+		"DeviceModeCapability",
+		"DeviceName",
+		"DeviceNameUserSet",
+		"FirewallVersion",
+		"FirmwareDLmethod",
+		"FirmwareLastChecked",
+		"FirmwareLastUpdate",
+		"Firmwareversion",
+		"FirstUseDate",
+		"ModelName",
+		"Otherhardwareversion",
+		"OthersoftwareVersion",
+		"SerialNumber",
+		"SignalStrength",
+		"SmartAgentversion",
+		"VPNVersion",
+	}
+	for _, key := range expected {
+		if _, ok := res[key]; !ok {
+			t.Errorf("Expected `%s` key in the response, but did not find it", key)
+		}
+	}
+
+	if debug {
+		for k, v := range res {
+			fmt.Printf("%v => %v\n", k, v)
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -155,3 +155,36 @@ Upload => unknown (float, apparently always 0.00)
 Download => unknown (float, apparently always 0.00)
 QosPriority => priority (int)
 ```
+
+---
+#### `client.GetDeviceInfo()`
+Obtains a map of k/v pairs with device info. The keys and values come exactly from the API.
+
+Usage:
+`response, error = client.GetDeviceInfo()`
+
+Return:
+- **response** - *`map[string]string`* - Key/value pairs straight from the API
+- **err** - Will be `nil` on success.
+
+The current keys returned, and their format is:
+```
+Description => description (string, apparently always "Netgear Smart Wizard 3.0, specification 1.6 version")
+DeviceMode => mode (int)
+DeviceModeCapability => capable modes (string, semicolon-separated ints, e.g., "0;1")
+DeviceName => name (string)
+DeviceNameUserSet => true|false (boolean)
+FirewallVersion => version (string, e.g., "net-wall 2.0")
+FirmwareDLmethod => protocol (string, e.g., "HTTPS")
+FirmwareLastChecked => date (string, format "2023_1.28_3:15:5")
+FirmwareLastUpdate => date (string, format "2023_1.28_3:15:5")
+Firmwareversion => version (string, e.g., "V2.7.3.22")
+FirstUseDate => date (string, format "Sunday, 30 Sep 2007 01:10:03")
+ModelName => name (string)
+Otherhardwareversion => version (string, apparently always "N/A")
+OthersoftwareVersion => version (string, apparently always "N/A")
+SerialNumber => serial number (string)
+SignalStrength => strength (int)
+SmartAgentversion => version (float)
+VPNVersion => version (apparently always empty)
+```


### PR DESCRIPTION
This PR adds `client.GetDeviceInfo()` to support the DeviceInfo/GetInfo call.

Note: GetInfo is one of those overloaded methods; for example, there's WLANConfiguration/GetInfo, Time/GetInfo, etc., so I tried to name the file and function to convey its precise meaning here, even though "GetDeviceInfo" is not a meaningful string to the SOAP API.